### PR TITLE
Fix undefined tailwind css class

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -14,7 +14,8 @@
   
   /* Remove default button styling to use Tailwind classes */
   button {
-    @apply border-0 bg-transparent p-0 font-inherit cursor-pointer;
+    @apply border-0 bg-transparent p-0 cursor-pointer;
+    font: inherit;
   }
   
   /* Clean focus styles */


### PR DESCRIPTION
Fixes build error by replacing non-existent Tailwind `font-inherit` class with standard CSS `font: inherit;`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d35e5b0-6866-4eb9-8afe-78b85f388131">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4d35e5b0-6866-4eb9-8afe-78b85f388131">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

